### PR TITLE
Comparison of queryID should use equals to avoid object comparison.

### DIFF
--- a/src/main/java/de/samply/bbmri/negotiator/control/component/FileUploadBean.java
+++ b/src/main/java/de/samply/bbmri/negotiator/control/component/FileUploadBean.java
@@ -204,7 +204,7 @@ public class FileUploadBean implements Serializable {
             return false;
         }
 
-        if(queryIdInteger != queryId) {
+        if(!queryIdInteger.equals(queryId)) {
             logger.error("QueryID of file "+queryIdInteger+" does not match QueryID "+queryId+" of this bean.");
             return false;
         }


### PR DESCRIPTION
Deletion of attachments is broken, this fixes the queryIdInteger and queryId comparison in FileUploadBean.
To ensure unboxing is working as intended for queryIdInteger and queryId equals is used now.