### PR TITLE
added a setQuery in initialise based on query_id

### DIFF
--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/lifecycle/RequestLifeCycleStatus.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/lifecycle/RequestLifeCycleStatus.java
@@ -42,6 +42,7 @@ public class RequestLifeCycleStatus {
     public void initialise() {
         try(Config config = ConfigFactory.get()) {
             initialise(DbUtil.getRequestStatus(config, query_id));
+            setQuery(DbUtil.getQueryFromIdAsQuery(config, query_id));
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
saving a query after editing leads to the following error:
```
Error

A server error occured. Please go back to the start page of the negotiator.
```
You only get the error with queries with the `LifeCycleRequestStatusStatus.STARTED`.
In the `requestLifeCycleStatus.contactCollectionRepresentativesIfNotContacted` an attempt is made to send a notification.

The problem is that query was never set, so `query.getId()` throws a NullPointerException.

The query is now set during the `initialise()` of `requestLifeCycleStatus` 