### PR TITLE
Added check if size of status of collectionLifeCycleStatus is 0

### DIFF
--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/lifecycle/RequestLifeCycleStatus.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/lifecycle/RequestLifeCycleStatus.java
@@ -136,7 +136,7 @@ public class RequestLifeCycleStatus {
         for(Integer collectionStatusListKey : collectionStatusList.keySet()) {
             CollectionLifeCycleStatus collectionLifeCycleStatus = collectionStatusList.get(collectionStatusListKey);
             List<Person> contacts = collectionLifeCycleStatus.getContacts();
-            if(collectionLifeCycleStatus == null) {
+            if(collectionLifeCycleStatus == null || collectionLifeCycleStatus.getStatus() == null) {
                 notreachableCollections = contactCollectionRepresentativesInCollection(userId, mailrecipients, collectionsString, notreachableCollections, collectionLifeCycleStatus, contacts);
                 for(Person person : contacts) {
                     emailAddressesAndNames.put(person.getAuthEmail(), person.getAuthName());


### PR DESCRIPTION
Collection Status was NULL and caused a Status Error when:
A request was created --> request save ---> request approved --> edit request --> add new search query (and another collection was added) --> request save.
This caused the status of the newly added Collection to be null.
Note if a collection is added before the start of the negotiation (approving of the request) everything worked fine.

Fix:
it was only checked if the collectionLifeCycleStatus was null not if there were 0 status' in the object
Tested:
only locally